### PR TITLE
fix vector y in lecture 2 slides

### DIFF
--- a/slides/lecture2-supervised-learning.ipynb
+++ b/slides/lecture2-supervised-learning.ipynb
@@ -2070,10 +2070,10 @@
     "\n",
     "Similarly, we can vectorize the target variables into a vector $y \\in \\mathbb{R}^n$ of the form\n",
     "$$ y = \\begin{bmatrix}\n",
-    "x^{(1)} \\\\\n",
-    "x^{(2)} \\\\\n",
+    "y^{(1)} \\\\\n",
+    "y^{(2)} \\\\\n",
     "\\vdots \\\\\n",
-    "x^{(n)}\n",
+    "y^{(n)}\n",
     "\\end{bmatrix}.$$"
    ]
   }


### PR DESCRIPTION
As discussed in class, I found a few extremely minor changes to the slides and was advised to create a pull request. In lecture2-supervised-learning.ipynb, I changed vector y (the last equation in the slide deck) to be a column of $y^{(1)} ... y^{(n)}$ instead of $x^{(1)} ... x^{(n)}$. 